### PR TITLE
Simplify 8bitBinarize.ijm

### DIFF
--- a/8bitBinarize.ijm
+++ b/8bitBinarize.ijm
@@ -8,24 +8,17 @@
 // ----------------------------------------------------------------------------------------------
 
 // clip the range of values to the [0,1] range
-getStatistics(area, mean, min, max, std, histogram);
-run("Subtract...", "value="+min);
+getStatistics(_, _, min, max, _, _);
+run("Subtract...", "value=" + min);
 diff = max - min + 1e-20
-run("Divide...", "value="+diff);
+run("Divide...", "value=" + diff);
 
 // Convert the image to 8-bit
-run("Multiply...", "value="+255);
-run("Window/Level...");
+run("Multiply...", "value=" + 255);
 setMinAndMax(0, 255);
-selectWindow("W&L");
-run("Close");
 run("8-bit");
 
 // Threshold the output.
-OptimalThreshold = 159
-setAutoThreshold("Default dark");
-setThreshold(OptimalThreshold, 255);
+optimalThreshold = 159
+setThreshold(optimalThreshold, 255);
 run("Convert to Mask");
-
-
-


### PR DESCRIPTION
This commit tries to make the macro more concise and readable by:
* removing unnecessary function calls (*Window/Level* and *Default threshold*)
* replacing unused variables in `getStatistics()` by underscores
* consistently adding spaces around operators for readability
* consistently using lower case first letters in variable names