### PR TITLE
auto flag_RGB in preprocessing macro

### DIFF
--- a/bioimage.io/per_sample_scale_range.ijm
+++ b/bioimage.io/per_sample_scale_range.ijm
@@ -27,8 +27,9 @@ max_percentile = 99.8;
 min_percentile = min_percentile/100;
 max_percentile = max_percentile/100;
 nBins = 256; // the larger the more accurate
+
 // Check if the image is RGB
-flag_rgb = 1;
+flag_rgb = !is("grayscale"); // "RGB = NOT (grayscale)"
 // Convert the RGB image as a stack of slices so it processes the intensity of each slice.
 if (flag_rgb==1){
 	run("Make Composite");


### PR DESCRIPTION
the pre-processing macro would automatically detect if the image to pre-process is RGB.  

With the previous macro version, if one just executes it without inspecting it, the `flag_RGB` is 1 by default which results in a not super intuitive error message with grayscale images, which I assume is the most common use case.  
This PR would prevent this error. 
